### PR TITLE
No more dependent induction/elimination besides the infrastructure lemmas

### DIFF
--- a/Stlc/DefinitionsSyntax.v
+++ b/Stlc/DefinitionsSyntax.v
@@ -41,11 +41,16 @@ Scheme Equality for typ.
 (* Expressions are indexed by the number of *bound variables*
    that appear in terms. *)
 
-Inductive exp : nat ->  Set :=  (*r expressions *)
- | var_b : forall {n}, fin n -> exp n
- | var_f : forall {n} (x:var), exp n
- | abs   : forall {n} (e:exp (S n)), exp n
- | app   : forall {n} (e1:exp n) (e2:exp n), exp n.
+Inductive exp (n : nat) : Set :=  (*r expressions *)
+ | var_b : fin n -> exp n
+ | var_f : forall (x:var), exp n
+ | abs   : forall (e:exp (S n)), exp n
+ | app   : forall (e1:exp n) (e2:exp n), exp n.
+
+Arguments var_b {n}%type_scope.
+Arguments var_f {n}%type_scope.
+Arguments abs {n}%type_scope.
+Arguments app {n}%type_scope.
 
 (* [Signature] creates a sigma type that allowing packing values with their
    constructor index.

--- a/Stlc/Lec2.v
+++ b/Stlc/Lec2.v
@@ -637,8 +637,7 @@ Proof.
   + inversion H0. subst. inversion H5.
   + left. simpl. auto.
   + destruct IHtyping1; auto.
-     ++ depelim e1; simpl in H2; try done; clear H2.
-        depelim H. inversion H2. subst. clear H2.
+     ++ destruct e1; simpl in H2; try done; clear H2.
         right.
         exists (open e2 e1).
         eauto.

--- a/Stlc/Lec2.v
+++ b/Stlc/Lec2.v
@@ -562,7 +562,7 @@ Lemma preservation : forall (E : ctx) e e' T,
 Proof.
   intros E e e' T H.
   generalize e'.
-  dependent induction H; intros e0' S; inversion S; subst.
+  induction H; intros e0' S; inversion S; subst.
   - inversion H; subst.
     pick fresh x for (L \u fv e0).
     rewrite (subst_intro _ _ x); auto.

--- a/Stlc/Lec2.v
+++ b/Stlc/Lec2.v
@@ -562,16 +562,15 @@ Lemma preservation : forall (E : ctx) e e' T,
 Proof.
   intros E e e' T H.
   generalize e'.
-  dependent induction H; intros e0' S; depelim S; subst.
-  - depelim H. inversion H0. subst.
+  dependent induction H; intros e0' S; inversion S; subst.
+  - inversion H; subst.
     pick fresh x for (L \u fv e0).
     rewrite (subst_intro _ _ x); auto.
     eapply typing_subst_simple; auto.
   - eauto.
 Qed.
 
-(* NOTE: instead of inversion for step derivation, need to use depelim. Otherwise get 
- existT equalities that need to be resolved via inj_pair2. *)
+(* UPDATE: No need for depelim anymore! Yay! *)
 
 (*************************************************************************)
 (** ** Progress *)

--- a/Stlc/Lemmas.v
+++ b/Stlc/Lemmas.v
@@ -112,7 +112,7 @@ Qed.
 Lemma size_exp_min :
 (forall n (e1 : exp n), (1 <= size_exp e1)%nat).
 Proof.
-  intros n e1.  dependent induction e1; default_simp.
+  intros n e1.  induction e1; default_simp.
 Qed.
 
 #[global] Hint Resolve size_exp_min : lngen.
@@ -140,8 +140,9 @@ Lemma size_exp_open_exp_wrt_exp_var :
 (forall k (e : exp (S k)) x,
   size_exp (open_exp_wrt_exp (var_f x) e) = size_exp e).
 Proof.
-intros k e x.
-dependent induction e; default_simp. destruct_option; default_simp.
+  enough (forall k (e : exp k) k1 x (e1 : exp (S k1)),
+             k = S k1 -> e ~= e1 -> size_exp (open_exp_wrt_exp (var_f x) e1) = size_exp e1) by eauto.
+  induction e; intros; subst; default_simp. destruct_option; default_simp.
 Qed.
 
 #[global] Hint Resolve size_exp_open_exp_wrt_exp_var : lngen.

--- a/Stlc/Lemmas.v
+++ b/Stlc/Lemmas.v
@@ -117,12 +117,13 @@ Qed.
 
 #[global] Hint Resolve size_exp_min : lngen.
 
+From Hammer Require Import Tactics.
 Lemma size_exp_close_exp_wrt_exp :
 (forall n1 (e1 : exp n1) x1,
   size_exp (close_exp_wrt_exp x1 e1) = size_exp e1).
 Proof.
-intros n1 e1 x1.  
-funelim (close_exp_wrt_exp x1 e1); default_simp. 
+  intros n1 e1 x1.
+  funelim (close_exp_wrt_exp x1 e1); default_simp. 
 Qed.
 
 #[global] Hint Resolve size_exp_close_exp_wrt_exp : lngen.


### PR DESCRIPTION
It turns out that the index of `exp` can be pulled out as a parameter. After making such a change, dependent induction is not really needed outside of the infrastructure lemmas. It is now possible to do regular induction on `e : exp k` when `k` is either a variable or a constant.

In the infrastructure lemmas, dependent induction is only needed when `k` is a composite expression that contains a variable that is referred to in the goal. In such a case, attempting to do `induction` will fail when the tactic tries to generalize `k`. That's a reasonable trade-off because the user of lngen only has to deal with `e : exp 0`  (and therefore can use regular destruct and induction) until they start writing their own fixpoint over `exp`.